### PR TITLE
fix: Hack to allow to level wait in ESLint parser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,8 @@ class Block {
 	}
 
 	add(text) {
-		this.texts.push(text);
+		// HACK: ESLint can't currently process top level await functions that EJS uses
+		this.texts.push(text.replace(/await /, '      '));
 	}
 
 	addFinal(thisText, endLine, endCol) {


### PR DESCRIPTION
This seems to be the only plugin I found that seems to work for EJS, but ran into an issue with templates using top level await statements.
ESLint won't support them till they become fully supported by TC39, so you get alot of `error  Parsing error: Unexpected token wiki` for any statements follow an `await`. This hack just let's ESLint pretend they aren't there and continue processing the code